### PR TITLE
Update README.md [Maximum Amp without Voltage Divider]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is based on https://github.com/RobTillaart/ACS712
 
 The code is working on ESP and ACS712-30A.
 
-Have in mind that without voltage divider on the ADC pin a 30A model will measure up to 20A.
+Have in mind that without voltage divider on the ADC pin a 30A model will measure up to 12A.
 
 Example yaml fragment:
 


### PR DESCRIPTION
I am not sure so correct me on this but:
Based on (simple) calculations i've done, i think 12A is maximum Amp we can get without a Voltage divider since datasheet says 66 Milli-Volt per Amp is the increase and **if** the ESP32 ADC can stand up to 3.3V (idk if this is right) thus it'll be 12A maximum current drawn possible to saturate the 3.3V and after that it'll go up, upto 5V which is +30A if i'm not wrong.